### PR TITLE
manual update to PieFed 1.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Federated forum and link aggregator, for your community
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://join.piefed.social/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://piefed.social/)
-[![Version: 1.3.0~ynh1](https://img.shields.io/badge/Version-1.3.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/piefed/)
+[![Version: 1.3.7~ynh1](https://img.shields.io/badge/Version-1.3.7~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/piefed/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/piefed"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -8,7 +8,7 @@ name = "PieFed"
 description.en = "Federated forum and link aggregator, for your community"
 description.fr = "Forum and aggrégateur de liens fédéré, pour votre communauté"
 
-version = "1.3.0~ynh1"
+version = "1.3.7~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -47,8 +47,8 @@ ram.runtime = "3G"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://codeberg.org/rimu/pyfedi/archive/v1.3.0.tar.gz"
-        sha256 = "80408af01a56b062d844983303d6cb27be5abdf589caa136ed3b910d366ed040"
+        url = "https://codeberg.org/rimu/pyfedi/archive/v1.3.7.tar.gz"
+        sha256 = "cb925d821f60bf9ab8d0ae04d9eb10f40115f2f027a20df6d915022c304f2652"
         autoupdate.strategy = "latest_forgejo_release"
 
     [resources.system_user]


### PR DESCRIPTION
[PieFed 1.3.7](https://codeberg.org/rimu/pyfedi/releases/tag/v1.3.7) fixes the installation issues seen in https://github.com/YunoHost-Apps/piefed_ynh/pull/6

Manually updated the files, don't know how if yunohost-bot does additional stuff.

I hope this is alright.