### PR TITLE
Upgrade to v1.6.13 (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Federated forum and link aggregator, for your community
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://join.piefed.social/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://piefed.social/)
-[![Version: 1.6.12~ynh1](https://img.shields.io/badge/Version-1.6.12~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/piefed/)
+[![Version: 1.6.13~ynh1](https://img.shields.io/badge/Version-1.6.13~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/piefed/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/piefed"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -8,7 +8,7 @@ name = "PieFed"
 description.en = "Federated forum and link aggregator, for your community"
 description.fr = "Forum and aggrégateur de liens fédéré, pour votre communauté"
 
-version = "1.6.12~ynh1"
+version = "1.6.13~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -47,8 +47,8 @@ ram.runtime = "3G"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://codeberg.org/rimu/pyfedi/archive/v1.6.12.tar.gz"
-        sha256 = "28efe7b8a47d66afec3fab158cf4b9b2aae9a163812462e5f046cca796369aaa"
+        url = "https://codeberg.org/rimu/pyfedi/archive/v1.6.13.tar.gz"
+        sha256 = "e6be65cc920cbe5fd20b6da100eda7c22bfefaf9f36438b344534aff5a5372fe"
         autoupdate.strategy = "latest_forgejo_release"
 
     [resources.system_user]


### PR DESCRIPTION
* Upgrade sources
- `main` v1.6.13: https://codeberg.org/rimu/pyfedi/releases/tag/v1.6.13

* Auto-update READMEs